### PR TITLE
Removed University Leader section from the website and navigation

### DIFF
--- a/course-single/course-content/git-github-content.html
+++ b/course-single/course-content/git-github-content.html
@@ -45,7 +45,6 @@
                 <ul>
                     <li><a class="nav-link" href="../../index.html">Home</a></li>
                     <li><a class="nav-link" href="../../courses.html">Courses</a></li>
-                    <li><a class="nav-link" href="../../index.html#universityleader">University Leader</a></li>
                     <li><a class="nav-link" href="../../index.html#team">Team</a></li>
                     <li><a class="nav-link" href="../../index.html#about">About Us</a></li>
                     <li><a class="nav-link scrollto" href="#contact">Contact Us</a></li>

--- a/course-single/course-content/java-dsa-bootcamp-content.html
+++ b/course-single/course-content/java-dsa-bootcamp-content.html
@@ -45,7 +45,6 @@
                 <ul>
                     <li><a class="nav-link" href="../../index.html">Home</a></li>
                     <li><a class="nav-link" href="../../courses.html">Courses</a></li>
-                    <li><a class="nav-link" href="../../index.html#universityleader">University Leader</a></li>
                     <li><a class="nav-link" href="../../index.html#team">Team</a></li>
                     <li><a class="nav-link" href="../../index.html#about">About Us</a></li>
                     <li><a class="nav-link scrollto" href="#contact">Contact Us</a></li>

--- a/course-single/git-github.html
+++ b/course-single/git-github.html
@@ -37,7 +37,6 @@
                 <ul>
                     <li><a class="nav-link" href="../index.html">Home</a></li>
                     <li><a class="nav-link" href="../courses.html">Courses</a></li>
-                    <li><a class="nav-link" href="../index.html#universityleader">University Leader</a></li>
                     <li><a class="nav-link" href="../index.html#team">Team</a></li>
                     <li><a class="nav-link" href="../index.html#about">About Us</a></li>
                     <li><a class="nav-link scrollto" href="#contact">Contact Us</a></li>

--- a/course-single/java-dsa-bootcamp.html
+++ b/course-single/java-dsa-bootcamp.html
@@ -37,7 +37,6 @@
                 <ul>
                     <li><a class="nav-link" href="../index.html">Home</a></li>
                     <li><a class="nav-link" href="../courses.html">Courses</a></li>
-                    <li><a class="nav-link" href="../index.html#universityleader">University Leader</a></li>
                     <li><a class="nav-link" href="../index.html#team">Team</a></li>
                     <li><a class="nav-link" href="../index.html#about">About Us</a></li>
                     <li><a class="nav-link scrollto" href="#contact">Contact Us</a></li>

--- a/courses.html
+++ b/courses.html
@@ -35,7 +35,6 @@
                 <ul>
                     <li><a class="nav-link" href="index.html">Home</a></li>
                     <li><a class="nav-link active" href="">Courses</a></li>
-                    <li><a class="nav-link" href="index.html#universityleader">University Leader</a></li>
                     <li><a class="nav-link" href="index.html#team">Team</a></li>
                     <li><a class="nav-link" href="index.html#about">About Us</a></li>
                     <li><a class="nav-link scrollto" href="#contact">Contact Us</a></li>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
                 <ul>
                     <li><a class="nav-link active" href="">Home</a></li>
                     <li><a class="nav-link" href="courses.html">Courses</a></li>
-                    <li><a class="nav-link scrollto" href="#universityleader">University Leader</a></li>
+                    <!-- <li><a class="nav-link scrollto" href="#universityleader">University Leader</a></li> -->
                     <li><a class="nav-link scrollto" href="#team">Team</a></li>
                     <li><a class="nav-link scrollto" href="#about">About Us</a></li>
                     <li><a class="nav-link scrollto" href="#contact">Contact Us</a></li>
@@ -320,7 +320,7 @@
 
 
         <!-- ======= University Leader Section ======= -->
-        <section id="universityleader" class="universityleader">
+        <!-- <section id="universityleader" class="universityleader">
             <div class="container">
 
                 <div class="text-center">
@@ -339,7 +339,7 @@
                     </div>
                 </div>
             </div>
-        </section>
+        </section> -->
         <!-- University Leader Section -->
 
 


### PR DESCRIPTION
As the University Leader Program has been cancelled permanenly, I commented out the **University Leader Section** code and also removed all the nav links of the University Leader section from

- course-single/course-content/java-dsa-bootcamp-content.html
- course-single/git-github.html
-  courses.html
- index.html