### PR TITLE
Added tabindex to "What makes our courses special?" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
                 </div>
 
                 <div class="row">
-                    <div class="col-lg-3 col-md-6 d-flex align-items-stretch">
+                    <div class="col-lg-3 col-md-6 d-flex align-items-stretch" tabindex="0">
                         <div class="icon-box">
                             <div class="icon"><i class="bx bx-data"></i></div>
                             <h4>Structured Learning</h4>
@@ -138,7 +138,7 @@
                         </div>
                     </div>
 
-                    <div class="col-lg-3 col-md-6 d-flex align-items-stretch mt-4 mt-md-0">
+                    <div class="col-lg-3 col-md-6 d-flex align-items-stretch mt-4 mt-md-0" tabindex="0">
                         <div class="icon-box">
                             <div class="icon"><i class="bx bx-notepad"></i></div>
                             <h4>Notes + Assignments</h4>
@@ -146,7 +146,7 @@
                         </div>
                     </div>
 
-                    <div class="col-lg-3 col-md-6 d-flex align-items-stretch mt-4 mt-lg-0">
+                    <div class="col-lg-3 col-md-6 d-flex align-items-stretch mt-4 mt-lg-0" tabindex="0">
                         <div class="icon-box">
                             <div class="icon"><i class="bx bx-message-dots"></i></div>
                             <h4>Doubt Support</h4>
@@ -154,10 +154,10 @@
                         </div>
                     </div>
 
-                    <div class="col-lg-3 col-md-6 d-flex align-items-stretch mt-4 mt-lg-0">
+                    <div class="col-lg-3 col-md-6 d-flex align-items-stretch mt-4 mt-lg-0" tabindex="0">
                         <div class="icon-box">
                             <div class="icon"><i class="bx bx-user-voice"></i></div>
-                            <h4>Guidance</h4>
+                            <h4 >Guidance</h4>
                             <p>Get expert guidance with career, open source and internships, jobs around the world.</p>
                         </div>
                     </div>


### PR DESCRIPTION
fixes#163

before when we try to navigate through the website using keyboard only(using tab key), then the cursor directly navigates from "our courses" section to directly "what community says about us section", but now added tabindex feature and the user gets to navigate through "what makes our courses special?" section too, using keyboard only.

hope you can see the outer black navigation box on "notes+assignments" box, added this similar box all these 4 boxes.

this is my first ever PR :), so I am a newbie, please forgive me if I did anything wrong, and do tell if want new changes.

![image](https://user-images.githubusercontent.com/79351160/135155807-8c4cd172-d04d-408c-ade6-11a83554ec0f.png)
