### PR TITLE
Adding CSS to improve some alignment

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -313,6 +313,8 @@ h6 {
 	height: 16px;
 	width: 34px;
 	transform: scale(1.5);
+	flex-wrap: wrap;
+	top: 4px;
 }
 
 .label .ball {


### PR DESCRIPTION

# Description
Adding CSS to improve
- Alignment of Light/Dark Mode switch button with other navigation buttons.
- Alignment of light and dark mode icon with the blue ball inside the Light/Dark Mode switch button

## Type of change

Please delete options that are not relevant.

- [x] User Interface


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# ScreenShots (if any) 
**Earlier:** 
![bad_align](https://user-images.githubusercontent.com/86077008/135656882-d082fdc5-ba77-4908-a8f5-c04a882cf9b2.png)

**Final:** 
![Final](https://user-images.githubusercontent.com/86077008/135656929-68936803-a527-468c-b690-94c550c33e1a.png)


