### PR TITLE
Updated Courses heading for better view

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -27,7 +27,7 @@ body {
 }
 
 div {
-    text-align: justify;
+    text-align: left;
     text-justify: inter-word;
   }
 


### PR DESCRIPTION
# Description
Fixes # (issue)
Updated line #29 of style.css
Changed the indentation of the headline of the Courses page for better view.

## Type of change

- [x] User Interface


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have ```npm run format``` before commiting
- [x] I replicated the UI with the Design 

# ScreenShots (if any) 
Previously:
![Screenshot (63)](https://user-images.githubusercontent.com/42652270/135746234-b4e123f8-ce4c-4883-869d-9cb3bdbed0e1.png)

Now:
![Screenshot (62)](https://user-images.githubusercontent.com/42652270/135746245-cf19c222-15c6-4d64-b565-b8c7ecbffee7.png)
