### PR TITLE
Fixed margin of social media icons in footer 

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1270,8 +1270,8 @@ section {
     color: #5f687b;
     line-height: 1;
     padding: 8px 0;
-    margin-right: 4px;
-    border-radius: 4px;
+    margin-right: 10px;
+    border-radius: 5px;
     text-align: center;
     width: 36px;
     height: 36px;


### PR DESCRIPTION
Description
Increased margin of social media icons in footer for proper alignment.
Fixes #246 

### ScreenShots

Previously:
![Screenshot (11)](https://user-images.githubusercontent.com/77191007/135756941-9445895b-4dee-44f5-97a6-feaf3a286c4d.png)

Fix:
![Screenshot (12)](https://user-images.githubusercontent.com/77191007/135756915-061deb7e-5a38-4c29-9589-6e6dff7fe881.png)

