### PR TITLE
Aligned NavBar items center and Dark theme button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -170,6 +170,7 @@ h6 {
     display: flex;
     list-style: none;
     align-items: center;
+    justify-content: center;
 }
 
 .navbar li {
@@ -180,8 +181,7 @@ h6 {
 .navbar a:focus {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 10px 0 10px 15px;
+    justify-content: center;
     font-family: "Raleway", sans-serif;
     font-size: 16px;
     font-weight: 700;
@@ -347,6 +347,11 @@ h6 {
     font-size: 0.7rem;
 }
 
+@media (max-width:1062px) and (min-width:991px){
+    .navbar{
+        margin-right: 3em;
+    }
+}
 
 @media (max-width: 1366px) {
     .navbar .dropdown .dropdown ul {


### PR DESCRIPTION
# Description
Fixes # (issue)

- The **Dark Theme Toggle button** was actually _overlapping_ with **Contact Us** item in navigation bar. 
Added a Media query to create a margin there, so as to arrange it properly. :heavy_check_mark: 
 
- The **Items in navigation bar** was aligned to the left on Mobile Screens. 
Edited the css file to align it **_Center_** to give a good look. :sparkles:

## Type of change

- [ ] User Interface

# ScreenShots  

### **Dark Theme Toggle button**


![commclassroom-dark](https://user-images.githubusercontent.com/69101976/135887662-3b925215-8d89-41f3-a09d-3a508dfd3c88.png)

### **Items in navigation bar**

![commclassroom-navbar](https://user-images.githubusercontent.com/69101976/135887681-73c9c0cd-a6f7-4078-a47c-5e7274236586.png)


