### PR TITLE
Increase Visibility of Icon in Hero Section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -541,7 +541,7 @@ h6 {
 }
 
 #hero .btn-watch-video i {
-    color: #009CFF;
+    color: #ffffff;
     font-size: 32px;
     line-height: 0;
     margin-right: 8px;
@@ -550,7 +550,7 @@ h6 {
 #hero .btn-watch-video:hover i {
     transform: scale(1.35);
     transition: 0.4s;
-    color: #16df7e;
+    color: #0017FF;
 }
 
 #hero .animated {


### PR DESCRIPTION
# Description
In the hero section, the video play icon is in blue which is not visible on the blue background. So the colour of the icon changes to white which is more visible on the blue background and also matches with the other content. And added a dark blue hover effect instead of green which is similar to the hover effect of the button beside it. Screenshots are attached bellow

## Type of change

Please delete options that are not relevant.

- [x] User Interface

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I replicated the UI with the Design 

# ScreenShots (if any) 
## Changes made in the colour of the icon without hover state
Here, the icon is not visible 
![image](https://user-images.githubusercontent.com/57897938/135903208-e3e73f7e-7b9c-4629-b26a-c47051bd9a80.png)

Here, the icon is clearly visible
![image](https://user-images.githubusercontent.com/57897938/135903255-227f4f25-9648-4601-84fb-6d981089defa.png)


## Hover Effect Colour Changes
Here, the hover colour is not matching with the UI
![image](https://user-images.githubusercontent.com/57897938/135903618-75fb518c-4ff8-4079-9736-c6b0a30e9ae9.png)

Here, the hover colour matches with the UI
![image](https://user-images.githubusercontent.com/57897938/135903692-4d83725b-f8d9-44e2-9f09-6ad03814a184.png)
![image](https://user-images.githubusercontent.com/57897938/135903751-8b37869d-83b4-4596-acfb-d3ab93a44044.png)


